### PR TITLE
Add some unit tests

### DIFF
--- a/pra_request_tracker/record_requests/models.py
+++ b/pra_request_tracker/record_requests/models.py
@@ -25,7 +25,7 @@ class Agency(BaseModel):
         """
         Deleting an Agency shouldn't be possible
         """
-        pass
+        raise NotImplementedError("Deleting Agencies not allowed")
 
     @cached_property
     def request_count(self):
@@ -66,7 +66,7 @@ class RecordRequest(BaseModel):
         """
         Deleteing a request shouldn't be possible. Instead change the status.
         """
-        pass
+        raise NotImplementedError("Deleting RecordRequests not allowed")
 
     @property
     def status_label(self):

--- a/pra_request_tracker/record_requests/tests.py
+++ b/pra_request_tracker/record_requests/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase  # noqa
-
-# Create your tests here.

--- a/pra_request_tracker/record_requests/tests/factories.py
+++ b/pra_request_tracker/record_requests/tests/factories.py
@@ -1,0 +1,30 @@
+from factory import Faker
+import factory
+from factory.django import DjangoModelFactory
+
+from ..models import Agency
+from ..models import RecordRequest
+from ..models import RecordRequestFile
+
+
+class AgencyFactory(DjangoModelFactory):
+    class Meta:
+        model = Agency
+
+    name = Faker("company")
+
+
+class RecordRequestFactory(DjangoModelFactory):
+    class Meta:
+        model = RecordRequest
+
+    agency = factory.SubFactory(AgencyFactory)
+
+
+class RecordRequestFileFactory(DjangoModelFactory):
+    class Meta:
+        model = RecordRequestFile
+
+    request = factory.SubFactory(RecordRequestFactory)
+    title = Faker("file_name")
+    file = factory.django.FileField()

--- a/pra_request_tracker/record_requests/tests/test_models.py
+++ b/pra_request_tracker/record_requests/tests/test_models.py
@@ -1,0 +1,66 @@
+import pytest
+from .factories import AgencyFactory
+from .factories import RecordRequestFactory
+from .factories import RecordRequestFileFactory
+
+from ..models import Agency, RecordRequestFile
+from ..models import RecordRequest
+
+
+@pytest.mark.django_db(transaction=True)
+def test_agency_request_count():
+    agency = AgencyFactory.create()
+
+    for _ in range(2):
+        RecordRequestFactory.create(agency=agency)
+
+    assert agency.request_count == 2
+
+
+@pytest.mark.django_db(transaction=True)
+def test_agency_delete():
+    agency = AgencyFactory.create()
+    pk = agency.pk
+    with pytest.raises(NotImplementedError):
+        agency.delete()
+
+    assert Agency.objects.filter(pk=pk).first() is not None
+
+
+@pytest.mark.django_db(transaction=True)
+def test_record_request_status_label():
+    status = RecordRequest.Status.INSTALLMENTS
+    record_request = RecordRequestFactory.create(status=str(status))
+
+    assert record_request.status_label == status.label
+
+
+@pytest.mark.django_db(transaction=True)
+def test_record_requeset_delete():
+    record_request = RecordRequestFactory.create()
+    pk = record_request.pk
+
+    with pytest.raises(NotImplementedError):
+        record_request.delete()
+
+    assert RecordRequest.objects.filter(pk=pk).first() is not None
+
+
+@pytest.mark.django_db(transaction=True)
+def test_record_request_files():
+    record_request = RecordRequestFactory.create()
+
+    files = []
+    for _ in range(3):
+        files.append(RecordRequestFileFactory.create(request=record_request))
+
+    assert files == list(record_request.files)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_record_request_file_delete():
+    file = RecordRequestFileFactory.create()
+    pk = file.pk
+    file.delete()
+
+    assert RecordRequestFile.objects.filter(pk=pk).first() is None

--- a/pra_request_tracker/record_requests/tests/test_models.py
+++ b/pra_request_tracker/record_requests/tests/test_models.py
@@ -7,7 +7,10 @@ from ..models import Agency, RecordRequestFile
 from ..models import RecordRequest
 
 
-@pytest.mark.django_db(transaction=True)
+transactional_db = pytest.mark.django_db(transaction=True)
+
+
+@transactional_db
 def test_agency_request_count():
     agency = AgencyFactory.create()
 
@@ -17,7 +20,7 @@ def test_agency_request_count():
     assert agency.request_count == 2
 
 
-@pytest.mark.django_db(transaction=True)
+@transactional_db
 def test_agency_delete():
     agency = AgencyFactory.create()
     pk = agency.pk
@@ -27,7 +30,7 @@ def test_agency_delete():
     assert Agency.objects.filter(pk=pk).first() is not None
 
 
-@pytest.mark.django_db(transaction=True)
+@transactional_db
 def test_record_request_status_label():
     status = RecordRequest.Status.INSTALLMENTS
     record_request = RecordRequestFactory.create(status=str(status))
@@ -35,7 +38,7 @@ def test_record_request_status_label():
     assert record_request.status_label == status.label
 
 
-@pytest.mark.django_db(transaction=True)
+@transactional_db
 def test_record_requeset_delete():
     record_request = RecordRequestFactory.create()
     pk = record_request.pk
@@ -46,7 +49,7 @@ def test_record_requeset_delete():
     assert RecordRequest.objects.filter(pk=pk).first() is not None
 
 
-@pytest.mark.django_db(transaction=True)
+@transactional_db
 def test_record_request_files():
     record_request = RecordRequestFactory.create()
 
@@ -57,7 +60,7 @@ def test_record_request_files():
     assert files == list(record_request.files)
 
 
-@pytest.mark.django_db(transaction=True)
+@transactional_db
 def test_record_request_file_delete():
     file = RecordRequestFileFactory.create()
     pk = file.pk

--- a/pra_request_tracker/record_requests/tests/test_views.py
+++ b/pra_request_tracker/record_requests/tests/test_views.py
@@ -1,3 +1,4 @@
+from typing import Any
 from django.test import TestCase
 from django.test import RequestFactory
 
@@ -8,7 +9,7 @@ from ..views import AgencyListView
 
 
 class ViewTestCase(TestCase):
-    view_cls = None
+    view_cls: Any
 
     def setUp(self):
         super().setUp()

--- a/pra_request_tracker/record_requests/tests/test_views.py
+++ b/pra_request_tracker/record_requests/tests/test_views.py
@@ -1,0 +1,37 @@
+from django.test import TestCase
+from django.test import RequestFactory
+
+from .factories import AgencyFactory
+from .factories import RecordRequestFactory
+
+from ..views import AgencyListView
+
+
+class ViewTestCase(TestCase):
+    view_cls = None
+
+    def setUp(self):
+        super().setUp()
+        self.request_factory = RequestFactory()
+
+    def get(self, *args, **kwargs):
+        self.request = self.request_factory.get(*args, **kwargs)
+        self.view = self.view_cls()
+        self.view.setup(self.request)
+        return self.view
+
+
+class AgencyListViewTestCase(ViewTestCase):
+    view_cls = AgencyListView
+
+    def test_prefetches_record_requests(self):
+        for _ in range(3):
+            agency = AgencyFactory.create()
+            for _ in range(4):
+                RecordRequestFactory.create(agency=agency)
+
+        view = self.get("/")
+        with self.assertNumQueries(2):
+            objects = list(view.get_queryset())
+            for object in objects:
+                self.assertEqual(object.request_count, 4)

--- a/pra_request_tracker/record_requests/views.py
+++ b/pra_request_tracker/record_requests/views.py
@@ -17,4 +17,3 @@ class AgencyDetailView(DetailView):
 
 class RecordRequestDetailView(DetailView):
     model = RecordRequest
-    queryset = RecordRequest.objects.prefetch_related("recordrequestfile_set")


### PR DESCRIPTION
Also removes an unnecessary prefetch_related from the RecordRequestDetailView. `prefetch_related` wasn't saving us any queries here because we always only had a single RecordRequest so there was no point in doing any joining in Python after two queries, we might as well just allow Django to run the second query normally for the `recordrequestfile_set` when the template requests it.