### PR TITLE
Add custom admin actions

### DIFF
--- a/pra_request_tracker/pra_request_tracker/record_requests/admin.py
+++ b/pra_request_tracker/pra_request_tracker/record_requests/admin.py
@@ -1,4 +1,7 @@
 from django.contrib import admin
+from django.http import QueryDict
+from django.urls import reverse
+from django.utils.html import format_html
 
 from .forms import AgencyForm, RecordRequestFileForm, RecordRequestForm
 from .models import Agency, RecordRequest, RecordRequestFile
@@ -7,8 +10,21 @@ from .models import Agency, RecordRequest, RecordRequestFile
 @admin.register(Agency)
 class AgencyAdmin(admin.ModelAdmin):
     form = AgencyForm
-    list_display = ("name",)
+    list_display = ("name", "agency_actions")
     search_fields = ("name",)
+
+    def agency_actions(self, obj):
+        query = QueryDict(mutable=True)
+        query.update({"agency": obj.pk})
+        return format_html(
+            '<a class="button custom-action" href="{}">Add request</a>'
+            '<a class="button custom-action" href="{}">View requests</a>',
+            f'{reverse("admin:record_requests_recordrequest_add")}?{query.urlencode()}',
+            f'{reverse("admin:record_requests_recordrequest_changelist")}?{query.urlencode()}',
+        )
+
+    agency_actions.short_description = "Actions"
+    agency_actions.allow_tags = True
 
 
 @admin.register(RecordRequest)
@@ -16,6 +32,7 @@ class RecordRequestAdmin(admin.ModelAdmin):
     form = RecordRequestForm
     list_display = (
         "title",
+        "record_request_actions",
         "agency",
         "tracking_number",
         "status",
@@ -26,6 +43,19 @@ class RecordRequestAdmin(admin.ModelAdmin):
     )
     search_fields = ("title", "agency", "tracking_number")
     autocomplete_fields = ("agency", "requester")
+
+    def record_request_actions(self, obj):
+        query = QueryDict(mutable=True)
+        query.update({"request": obj.pk})
+        return format_html(
+            '<a class="button custom-action" href="{}">Add file</a>'
+            '<a class="button custom-action" href="{}">View files</a>',
+            f'{reverse("admin:record_requests_recordrequestfile_add")}?{query.urlencode()}',
+            f'{reverse("admin:record_requests_recordrequestfile_changelist")}?{query.urlencode()}',
+        )
+
+    record_request_actions.short_description = "Actions"
+    record_request_actions.allow_tags = True
 
 
 @admin.register(RecordRequestFile)

--- a/pra_request_tracker/pra_request_tracker/static/css/admin.css
+++ b/pra_request_tracker/pra_request_tracker/static/css/admin.css
@@ -1,0 +1,7 @@
+.custom-action {
+    white-space: nowrap;
+}
+
+.custom-action:not(:first-child) {
+    margin-left: 1em;
+}

--- a/pra_request_tracker/pra_request_tracker/templates/admin/base_site.html
+++ b/pra_request_tracker/pra_request_tracker/templates/admin/base_site.html
@@ -1,0 +1,6 @@
+{% extends "admin/base.html" %}
+{% load static %}
+
+{% block extrastyle %}
+  <link rel='stylesheet' href='{% static 'css/admin.css' %}'>
+{% endblock %}


### PR DESCRIPTION
Adds some buttons to the agency and record request admin lists to make it easier to add requests for an agency and files for a request.

Also adds some minimal new custom CSS for the admin to support this feature.

<img width="2032" alt="Captura de Tela 2021-07-19 às 19 37 18" src="https://user-images.githubusercontent.com/24264157/126253549-577e6ec2-4293-48c0-964d-deddadc24b4f.png">
<img width="2032" alt="Captura de Tela 2021-07-19 às 19 37 12" src="https://user-images.githubusercontent.com/24264157/126253553-8f6071b1-de3d-42c2-879d-c8932f24a199.png">
