### PR TITLE
Fix alignment on correspondence bodies

### DIFF
--- a/pra_request_tracker/pra_request_tracker/templates/record_requests/recordrequest_detail.html
+++ b/pra_request_tracker/pra_request_tracker/templates/record_requests/recordrequest_detail.html
@@ -42,9 +42,7 @@
                     </p>
                 </div>
                 <div class="card-body">
-                    <pre class="card-text correspondence-body">
-                        {{ correspondence.body }}
-                    </pre>
+                    <pre class="card-text correspondence-body">{{ correspondence.body }}</pre>
                 </div>
                 {% if correspondence.recordrequestfile_set.all %}
                 <div class="card-footer">


### PR DESCRIPTION
I noticed that, due to the way pre-formatted text works, the body of the correspondences always starts off with a significant indent. This should hopefully address the extra whitespace.

![Screenshot_2021-09-12_16-43-55](https://user-images.githubusercontent.com/10214785/133006604-5b4a97f3-5fc4-496f-bdb1-15e09ccbd97c.png)
