### PR TITLE
Bugfix: Wrap preformatted text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 media
 
 .idea/
+*.swp

--- a/pra_request_tracker/pra_request_tracker/static/css/frontend.css
+++ b/pra_request_tracker/pra_request_tracker/static/css/frontend.css
@@ -1,0 +1,3 @@
+pre {
+    white-space: pre-wrap;
+}

--- a/pra_request_tracker/pra_request_tracker/templates/base.html
+++ b/pra_request_tracker/pra_request_tracker/templates/base.html
@@ -16,6 +16,7 @@
 
         {% block css %}
         <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+        <link rel='stylesheet' href='{% static 'css/frontend.css' %}'>
         {% endblock %}
         {% block javascript %}
 


### PR DESCRIPTION
Small modification to our pre-formatted blocks so that the text wraps appropriately. Also added swap files to the gitignore.

## Before
![Screenshot_2021-09-28_21-08-35](https://user-images.githubusercontent.com/10214785/135201842-28ea82cc-e018-41c1-af71-23a782bd1c55.png)

## After
![Screenshot_2021-09-28_21-08-45](https://user-images.githubusercontent.com/10214785/135201859-8cb30fd0-531b-4576-8f44-bc56d90a3665.png)


